### PR TITLE
Zone.log fix + batch file directory issue

### DIFF
--- a/HSbotRunner.bat
+++ b/HSbotRunner.bat
@@ -1,4 +1,4 @@
-py -3.11 -m venv %~dp0MFB
-%~dp0MFB\Scripts\python.exe -m pip install -r requirements_win.txt
-%~dp0MFB\Scripts\python.exe main.py
+py -3.11 -m venv "%~dp0MFB"
+MFB\Scripts\python.exe -m pip install -r requirements_win.txt
+MFB\Scripts\python.exe main.py
 pause

--- a/modules/settings/conf/settings.py
+++ b/modules/settings/conf/settings.py
@@ -2,6 +2,9 @@ import logging
 import pathlib
 import shutil
 
+import sys
+import os
+
 from modules.exceptions import MissingGameDirectory, UnsetGameDirectory, SettingsError
 from modules.file_utils import parseINI, readINI
 from modules.utils import update
@@ -39,8 +42,12 @@ def get_system_user_settings(system_settings_filename, user_settings_filename):
         if not game_dir.is_dir():
             raise MissingGameDirectory(f"Game directory ({game_dir}) does not exist")
         else:
+            logs_dir = (settings_dict["gamedir"] + "/Logs")
+            subdirectories = os.listdir(logs_dir)
+            logs = os.listdir(logs_dir + "/" + subdirectories[len(subdirectories) - 1])
+
             settings_dict["zonelog"] = pathlib.PurePath(
-                game_dir, "Logs/Zone.log"
+                game_dir, "Logs/" + subdirectories[len(subdirectories) - 1] + "/" + logs[len(logs) - 1]
             ).as_posix()
 
         log.info("Settings")

--- a/modules/settings/conf/settings.py
+++ b/modules/settings/conf/settings.py
@@ -44,10 +44,9 @@ def get_system_user_settings(system_settings_filename, user_settings_filename):
         else:
             logs_dir = (settings_dict["gamedir"] + "/Logs")
             subdirectories = os.listdir(logs_dir)
-            logs = os.listdir(logs_dir + "/" + subdirectories[len(subdirectories) - 1])
 
             settings_dict["zonelog"] = pathlib.PurePath(
-                game_dir, "Logs/" + subdirectories[len(subdirectories) - 1] + "/" + logs[len(logs) - 1]
+                game_dir, "Logs/" + subdirectories[len(subdirectories) - 1] + "/Zone.log"
             ).as_posix()
 
         log.info("Settings")


### PR DESCRIPTION
There was another bug that I found with the .bat file where it would crash because of a space in the directory if the project path had a folder with a space in it.